### PR TITLE
Upgrade UAA to 3.2.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,6 @@
 [submodule "src/uaa"]
 	path = src/uaa
 	url = https://github.com/18F/cg-uaa.git
-	branch = 3.0.1-18f
 [submodule "src/collector"]
 	path = src/collector
 	url = https://github.com/18F/collector.git


### PR DESCRIPTION
We brought master on cg-uaa to current, so this just removes the branch specifier :)
