### PR TITLE
update the UAA release to support > 128-bit encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # BOSH Release for 18f-cf
 
+## Export Warning
+
+This fork of the UAA release includes > 128-bit encryption. The software may be subject to import or export regulations outside the United States.
+
 ## Usage
 
 To use this bosh release, first upload it to your bosh:

--- a/packages/uaa/packaging
+++ b/packages/uaa/packaging
@@ -7,6 +7,9 @@ if [[ $? != 0 ]] ; then
   exit 1
 fi
 
+# Allow for > 128bit encryption
+unzip  ${BOSH_COMPILE_TARGET}/openjdk/jce_policy-8.zip && mv UnlimitedJCEPolicyJDK8/*.jar jdk/jre/lib/security/ && rm -fr UnlimitedJCEPolicyJDK8
+
 # latest JDK release didn't have correct permissions
 chmod -R a+r jdk
 

--- a/packages/uaa/spec
+++ b/packages/uaa/spec
@@ -1,8 +1,8 @@
 ---
 name: uaa
 dependencies:
-- 18f-ruby-2.1.7
 files:
 - uaa/**/*
+- openjdk/jce_policy-8.zip
 - openjdk/openjdk-1.8.0_91-x86_64-mountainlion.tar.gz
 - openjdk/openjdk-1.8.0_91-x86_64-trusty.tar.gz


### PR DESCRIPTION
@mogul @NoahKunin,
This is the change that was discussed to include the [JCE Unlimited Strength Policy files](http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html) to allow us to use AES256 for encrypted assertions.

Thankfully, due to the way these policy files need to be deployed we didn't have to include this change into our UAA fork, it could be done entirely in the cf release which is now the repo that carries the requested export warning you'll see below.

Please let me know if we need to make any other changes to be compliant.  I plan to get this change merged and release to staging tomorrow.  
