### PR TITLE
re-enable invitation related settings in UAA login config template

### DIFF
--- a/jobs/uaa/templates/login.yml.erb
+++ b/jobs/uaa/templates/login.yml.erb
@@ -74,6 +74,9 @@ logout:
    <% end %>
 
 login:
+  <% if_p('login.invitations_enabled') do |company_name| %>
+    invitationsEnabled: <%= company_name %>
+  <% end %>
   branding:
   <% if_p('login.branding.company_name') do |company_name| %>
     companyName: <%= company_name %>
@@ -90,6 +93,9 @@ login:
   <% if_p('login.branding.footer_links') do |footer_links| %>
     footerLinks: <% footer_links.each do |key,val| %>
       <%= key %>: <%= val %><% end %>
+  <% end %>
+  <% if_p('login.branding.from_address') do |company_name| %>
+    fromAddress: <%= company_name %>
   <% end %>
 <% if_p('login.home_redirect') do |home_redirect| %>
   homeRedirect: <%= home_redirect %>


### PR DESCRIPTION
Missed these when we pulled in the upstream job template changes.
